### PR TITLE
Small change to allow require to work with select boxes with disabled selected initial values.

### DIFF
--- a/src/jquery.validity.core.js
+++ b/src/jquery.validity.core.js
@@ -299,7 +299,10 @@ $.fn.extend({
         return validate(
             this,
             function(obj) {
-                return !!$(obj).val().length;
+                if ($(obj).val()) {
+                    return !!$(obj).val().length;
+                }
+                return false;
             },
             msg || $.validity.messages.require
         );


### PR DESCRIPTION
In the require function, add a check to see if val() is null or undefined, if it is then we return false (invalid).  This allows the require function to work with select boxes with a disabled selected value, such as:
<select id="month">
<option disabled="" selected="" value="">Month</option>
<option value="1">January</option>
...
</select>

That way we can just do $(#month).require() like a text box.  
-James
