### PR TITLE
Update jquery.validity.css

### DIFF
--- a/src/jquery.validity.css
+++ b/src/jquery.validity.css
@@ -10,7 +10,7 @@ label.error {
     background-repeat:no-repeat;
     padding:2px;
     padding-left:18px;
-    -moz-border-radius:4px;
+    border-radius:4px;
     -webkit-border-radius: 4px;
 }
 


### PR DESCRIPTION
-moz- is obsoleted for firefox. The current LTS version also supports it without -moz-
- this makes it also working for Ie9/Ie10/Ie11
