### PR TITLE
Update jquery.validity.outputs.js

### DIFF
--- a/src/jquery.validity.outputs.js
+++ b/src/jquery.validity.outputs.js
@@ -67,9 +67,11 @@
 // Install the label output.
 (function($) {
     function getIdentifier($obj) {
-        return $obj.attr('id').length ?
-            $obj.attr('id') :
-            $obj.attr('name');
+        if ($obj.attr('id') || $obj.attr('name')) {
+            return $obj.attr('id').length ? $obj.attr('id') : $obj.attr('name');
+        } else {
+            return '';
+        }
     }
 
     $.validity.outputs.label = {


### PR DESCRIPTION
Fixes label rendering for anonymous items.

Jquery selector for validation used on the 'class' of an item that has no ID. Validity can validate it perfectly but the Label rendering does not show in this case (due to the fact that $obj.attr('id') and $obj.attr('name') are undefined.

Off course the label is not attached to the item in this case but it won't break the entire validation step.
