### PR TITLE
fix border for TR errors

### DIFF
--- a/src/jquery.validity.css
+++ b/src/jquery.validity.css
@@ -41,7 +41,7 @@ label.error {
  */
 .validity-summary-container { display:none; }
 .validity-summary-output ul { }
-.validity-erroneous { border:solid 2px #f56600 !important; }
+.validity-erroneous,.validity-erroneous TD { border:solid 2px #f56600 !important; }
 
 
 


### PR DESCRIPTION
Fixes the class on tables where it was put on the TR. As for a TR border does not work.

E.g. in this case:
<table id="ItemID53637" cellspacing="0" cellpadding="2" border="0">
<tr>
<td></td>
<td class="QID53637 validity-erroneous">
<td class="valMargin"> </td>
</tr>

<table id="ItemID53637" cellspacing="0" cellpadding="2" border="0">
<tr class="validity-erroneous">
<td></td>
<td class="QID53637">
<td class="valMargin"> </td>
</tr>
