### PR TITLE
Update jquery.validity.css

### DIFF
--- a/src/jquery.validity.css
+++ b/src/jquery.validity.css
@@ -53,9 +53,7 @@ label.error {
     padding:3px;
     width:16em;
     
-    border-width:1px;
-    border-color:#555;
-    border-style:solid;
+    border:1px solid #555;
     color:#111;
     
     position: absolute;


### PR DESCRIPTION
Shorter notation makes it faster to download for browsers. Unless you use a minifier that optimizes this - but not every minifier supports that.
