### PR TITLE
Update jquery.validity.core.js

### DIFF
--- a/src/jquery.validity.core.js
+++ b/src/jquery.validity.core.js
@@ -905,7 +905,7 @@ $.fn.extend({
             this,
 
             function(obj) {
-                return !$(obj).is(":checkbox") || $(obj).is(":checked")
+                return !$(obj).is(":checkbox") || $(obj).is(":checked");
             },
 
             msg || $.validity.messages.checkboxChecked


### PR DESCRIPTION
added missing ;

I don't know why but firefox and chrome both change it to have changed all lines. Only change is L:908      
-                return !$(obj).is(":checkbox") || $(obj).is(":checked")
  L:908  
-                return !$(obj).is(":checkbox") || $(obj).is(":checked");
