### PR TITLE
adding 'options' section to $.validity.outputs.summary output option to ...

### DIFF
--- a/src/jquery.validity.outputs.js
+++ b/src/jquery.validity.outputs.js
@@ -219,6 +219,11 @@
         buffer = [];
 
     $.validity.outputs.summary = {
+        options:{
+            // Configurable container selector to facilitate having multiple containers on one page
+            // Defaults to standard selector defined above
+            container : container
+        },
         start:function() {
             $(errors).removeClass(erroneous);
             buffer = [];
@@ -226,7 +231,7 @@
 
         end:function(results) {
             // Hide the container and empty its summary.
-            $(container)
+            $(this.options.container)
                 .stop()
                 .hide()
                 .find("ul")
@@ -239,10 +244,10 @@
                 for (var i = 0; i < buffer.length; ++i) {
                     $(wrapper)
                         .text(buffer[i])
-                        .appendTo(container + " ul");
+                        .appendTo(this.options.container + " ul");
                 }
 
-                $(container).show();
+                $(this.options.container).show();
                 
                 // If scrollTo is enabled, scroll the page to the first error.
                 if ($.validity.settings.scrollTo) {
@@ -262,10 +267,10 @@
         
         container:function() {
             document.write(
-                "<div class=\"validity-summary-container\">" + 
+                    "<div class=\"" + this.options.container + "\">" +
                     "The form didn't submit for the following reason(s):" +
                     "<ul></ul>" +
-                "</div>"
+                    "</div>"
             );
         }
     };


### PR DESCRIPTION
...be able to define custom selectors for the validation output div, this helps with having two output containers on the same page for two different forms

Created this so that if you have two forms on a page and wanted two different summary boxes you could update like this:

``` javascript
  $("#loginForm").validity(function() {
       // standard output summary class nested inside of the current form element
        $.validity.outputs.summary.options.container= "#loginForm " + $.validity.outputs.summary.options.container;
        $("#login_email").require().match('email');
        $("#login_password").require();
    });
  $("#loginForm2").validity(function() {
        $.validity.outputs.summary.options.container= "#completely-new-container-not-nested-in-my-form";
        $("#login_email2").require().match('email');
        $("#login_password2").require();
    });
```
