### PR TITLE
Scrollto does not work when the value is filtered

### DIFF
--- a/src/jquery.validity.core.js
+++ b/src/jquery.validity.core.js
@@ -775,9 +775,7 @@ $.fn.extend({
                      
                      // raise the error - aggregate will use last repeated value
                      raiseAggregateError(
-                        $reduction.filter(
-                            "[value=\'" + repeatedVal[i] + "\']"
-                        ),
+                        $reduction,
                         msg
                     );
                 }


### PR DESCRIPTION
If configured like this:

$.validity.setup({ outputMode:"tooltip",useInfer:false,scrollTo:true });

An error is rendered with jquery 1.12 since an id is missing.